### PR TITLE
예약 ID로 중복 리뷰 생성 방지

### DIFF
--- a/src/main/java/com/qring/review/application/v1/service/ReviewServiceV1.java
+++ b/src/main/java/com/qring/review/application/v1/service/ReviewServiceV1.java
@@ -1,5 +1,6 @@
 package com.qring.review.application.v1.service;
 
+import com.qring.review.application.global.exception.DuplicateResourceException;
 import com.qring.review.application.global.exception.EntityNotFoundException;
 import com.qring.review.application.global.exception.UnauthorizedAccessException;
 import com.qring.review.application.v1.message.KafkaMessageProducerV1;
@@ -36,6 +37,11 @@ public class ReviewServiceV1 {
 
     @Transactional
     public ReviewPostResDTOV1 postBy(String passport, PostReviewReqDTOV1 dto) {
+
+        // 예약 ID로 중복 리뷰 조회
+        if (reviewRepository.findByReservationIdAndDeletedAtIsNull(dto.getReview().getReservationId()).isPresent()) {
+            throw new DuplicateResourceException("해당 예약으로 작성된 리뷰가 이미 존재합니다.");
+        }
 
         validateUserRole(PassportUtil.getRole(passport), Set.of(ROLE_ADMIN, ROLE_CUSTOMER));
 

--- a/src/main/java/com/qring/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/qring/review/domain/repository/ReviewRepository.java
@@ -18,4 +18,7 @@ public interface ReviewRepository {
     // 리뷰 저장
     ReviewEntity save(ReviewEntity categoryEntity);
 
+    // 예약 ID로 중복 리뷰 조회
+    Optional<ReviewEntity> findByReservationIdAndDeletedAtIsNull(Long id);
+
 }

--- a/src/main/java/com/qring/review/infrastructure/repository/JpaReviewRepository.java
+++ b/src/main/java/com/qring/review/infrastructure/repository/JpaReviewRepository.java
@@ -13,4 +13,6 @@ public interface JpaReviewRepository extends JpaRepository<ReviewEntity, Long> {
     // 특정 ID로 삭제되지 않은 식당 조회
     Optional<ReviewEntity> findByIdAndDeletedAtIsNull(Long id);
 
+    // 예약 ID로 중복 리뷰 조회
+    Optional<ReviewEntity> findByReservationIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/qring/review/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/qring/review/infrastructure/repository/ReviewRepositoryImpl.java
@@ -35,4 +35,11 @@ public class ReviewRepositoryImpl implements ReviewRepository {
         return jpaReviewRepository.save(ReviewEntity);
     }
 
+    // 예약 ID로 중복 리뷰 조회
+    @Override
+    public Optional<ReviewEntity> findByReservationIdAndDeletedAtIsNull(Long id) {
+        return jpaReviewRepository.findByReservationIdAndDeletedAtIsNull(id);
+    }
+
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #19 

## 📝 Description

- 리뷰 생성시 예약번호로 이미 작성한 리뷰가 있는지 확인하고 예약 하나당 하나의 리뷰만 작성할 수 있도록 개선했습니다.
- 개선 후
- 이미 작성한 리뷰가 있을 경우 아래와 같이 나타납니다.
![image](https://github.com/user-attachments/assets/1f3f8ab2-4c36-4680-b5f8-c9479743f452)

## 💬 To Reivewers




